### PR TITLE
chore: add genesis collator

### DIFF
--- a/passet-hub-runtime/src/genesis_config_presets.rs
+++ b/passet-hub-runtime/src/genesis_config_presets.rs
@@ -74,29 +74,12 @@ pub fn get_preset(id: &PresetId) -> Option<Vec<u8>> {
 	use preset_names::*;
 	let patch = match id.as_ref() {
 		PRESET_GENESIS => passet_hub_genesis(
-			// initial collators.
-			vec![
-				(
-					hex!("9cfd429fa002114f33c1d3e211501d62830c9868228eb3b4b8ae15a83de04325").into(),
-					hex!("9cfd429fa002114f33c1d3e211501d62830c9868228eb3b4b8ae15a83de04325")
-						.unchecked_into(),
-				),
-				(
-					hex!("12a03fb4e7bda6c9a07ec0a11d03c24746943e054ff0bb04938970104c783876").into(),
-					hex!("12a03fb4e7bda6c9a07ec0a11d03c24746943e054ff0bb04938970104c783876")
-						.unchecked_into(),
-				),
-				(
-					hex!("1256436307dfde969324e95b8c62cb9101f520a39435e6af0f7ac07b34e1931f").into(),
-					hex!("1256436307dfde969324e95b8c62cb9101f520a39435e6af0f7ac07b34e1931f")
-						.unchecked_into(),
-				),
-				(
-					hex!("98102b7bca3f070f9aa19f58feed2c0a4e107d203396028ec17a47e1ed80e322").into(),
-					hex!("98102b7bca3f070f9aa19f58feed2c0a4e107d203396028ec17a47e1ed80e322")
-						.unchecked_into(),
-				),
-			],
+			// One collator at genesis.
+			vec![(
+				hex!("ba665b203800a42e7bf67dcf77c77fb2ff7ece897fb32d395a074f786a7cbb23").into(),
+				hex!("ba665b203800a42e7bf67dcf77c77fb2ff7ece897fb32d395a074f786a7cbb23")
+					.unchecked_into(),
+			)],
 			Vec::new(),
 			PASSET_HUB_ED * 4096,
 			PASSET_HUB_PARA_ID.into(),


### PR DESCRIPTION
Includes an initial collator in the genesis config of passet-hub.

The public key for this collator session pair being: `5GH7AoR6ucYrqnTdtwhnVUS9GLK5DV11WTEXhYPesJNPMAwtp`.
Although not advisable, no different key is provided as stash account.