### PR TITLE
chore: add production build profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
+[profile.production]
+codegen-units = 1
+inherits = "release"
+lto = true
+
 [workspace.package]
 authors = [ "Parity Technologies <admin@parity.io>", "R0GUE <go@r0gue.io>" ]
 description = "Paseo variant of Asset Hub parachain runtime"


### PR DESCRIPTION
Includes production build profile. Mainly as a way of producing a smaller runtime during the build.