### PR TITLE
chore(revive): update EVM ChainID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4955,7 +4955,7 @@ dependencies = [
 
 [[package]]
 name = "passet-hub-runtime"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "asset-test-utils",
  "assets-common",

--- a/passet-hub-runtime/Cargo.toml
+++ b/passet-hub-runtime/Cargo.toml
@@ -6,7 +6,7 @@ homepage = { workspace = true }
 license = { workspace = true }
 name = "passet-hub-runtime"
 repository = { workspace = true }
-version = "0.1.0"
+version = "0.1.1"
 
 [lints]
 workspace = true

--- a/passet-hub-runtime/src/constants.rs
+++ b/passet-hub-runtime/src/constants.rs
@@ -1,3 +1,5 @@
+use hex_literal::hex;
+
 /// Universally recognized accounts.
 pub mod account {
 	use frame_support::PalletId;
@@ -238,3 +240,7 @@ pub mod system_parachain {
 
 /// Paseo Treasury pallet instance.
 pub const TREASURY_PALLET_ID: u8 = 19;
+
+/// The genesis hash of the Paseo testnet. Used to identify it.
+pub const PASEO_GENESIS_HASH: [u8; 32] =
+	hex!["77afd6190f1554ad45fd0d31aee62aacc33c6db0ea801129acb813f913e0764f"];

--- a/passet-hub-runtime/src/lib.rs
+++ b/passet-hub-runtime/src/lib.rs
@@ -134,7 +134,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: alloc::borrow::Cow::Borrowed("passet-hub"),
 	authoring_version: 1,
 	// The spec version from `asset-hub-westend-runtime` is periodically promoted to passet-hub's.
-	spec_version: 1_018_002,
+	spec_version: 1_018_003,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 16,
@@ -1088,7 +1088,7 @@ impl pallet_revive::Config for Runtime {
 	type RuntimeHoldReason = RuntimeHoldReason;
 	type CodeHashLockupDepositPercent = CodeHashLockupDepositPercent;
 	type Xcm = pallet_xcm::Pallet<Self>;
-	type ChainId = ConstU64<420_420_421>;
+	type ChainId = ConstU64<420_420_422>;
 	type NativeToEthRatio = ConstU32<1_000_000>; // 10^(18 - 12) Eth is 10^18, Native is 10^12.
 	type EthGasEncoder = ();
 	type FindAuthor = <Runtime as pallet_authorship::Config>::FindAuthor;

--- a/passet-hub-runtime/src/xcm_config.rs
+++ b/passet-hub-runtime/src/xcm_config.rs
@@ -15,7 +15,8 @@
 
 use super::{
 	constants::{
-		account::POLKADOT_TREASURY_PALLET_ID, system_parachain::COLLECTIVES_ID, TREASURY_PALLET_ID,
+		account::POLKADOT_TREASURY_PALLET_ID, system_parachain::COLLECTIVES_ID, PASEO_GENESIS_HASH,
+		TREASURY_PALLET_ID,
 	},
 	AccountId, AllPalletsWithSystem, Assets, Authorship, Balance, Balances, BaseDeliveryFee,
 	CollatorSelection, DepositPerByte, DepositPerItem, FeeAssetId, ForeignAssets,
@@ -62,10 +63,6 @@ use xcm_builder::{
 	WithLatestLocationConverter, WithUniqueTopic, XcmFeeManagerFromComponents,
 };
 use xcm_executor::XcmExecutor;
-
-/// The genesis hash of the Paseo testnet. Used to identify it.
-pub const PASEO_GENESIS_HASH: [u8; 32] =
-	hex!["77afd6190f1554ad45fd0d31aee62aacc33c6db0ea801129acb813f913e0764f"];
 
 parameter_types! {
 	pub const RootLocation: Location = Location::here();

--- a/passet-hub-runtime/tests/tests.rs
+++ b/passet-hub-runtime/tests/tests.rs
@@ -36,8 +36,10 @@ use frame_support::{
 };
 use hex_literal::hex;
 use parachains_common::{AccountId, AssetIdForTrustBackedAssets, AuraId, Balance};
-use paseo_parachains_constants::{consensus::*, currency::UNITS, fee::WeightToFee};
 use passet_hub_runtime::{
+	constants::{
+		consensus::*, currency::UNITS, fee::WeightToFee, system_parachain::*, PASEO_GENESIS_HASH,
+	},
 	xcm_config,
 	xcm_config::{
 		bridging, AssetFeeAsExistentialDepositMultiplierFeeCharger, CheckingAccount,
@@ -45,20 +47,17 @@ use passet_hub_runtime::{
 		LocationToAccountId, StakingPot, TrustBackedAssetsPalletLocation, WestendLocation,
 		XcmConfig,
 	},
-	AllPalletsWithoutSystem, Assets, Balances, Block, ExistentialDeposit, ForeignAssets,
-	ForeignAssetsInstance, MetadataDepositBase, MetadataDepositPerByte, ParachainSystem,
-	PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, SessionKeys,
-	ToRococoXcmRouterInstance, TrustBackedAssetsInstance, XcmpQueue,
+	AllPalletsWithoutSystem, AssetConversion, AssetDeposit, Assets, Balances, Block,
+	CollatorSelection, ExistentialDeposit, ForeignAssets, ForeignAssetsInstance,
+	MetadataDepositBase, MetadataDepositPerByte, ParachainSystem, PolkadotXcm, Runtime,
+	RuntimeCall, RuntimeEvent, RuntimeOrigin, SessionKeys, System, ToRococoXcmRouterInstance,
+	TrustBackedAssetsInstance, XcmpQueue,
 };
-pub use passet_hub_runtime::{AssetConversion, AssetDeposit, CollatorSelection, System};
 use sp_consensus_aura::SlotDuration;
 use sp_core::crypto::Ss58Codec;
 use sp_runtime::{traits::MaybeEquivalence, Either};
 use std::{convert::Into, ops::Mul};
-use xcm::latest::{
-	prelude::{Assets as XcmAssets, *},
-	ROCOCO_GENESIS_HASH,
-};
+use xcm::latest::prelude::{Assets as XcmAssets, *};
 use xcm_builder::WithLatestLocationConverter;
 use xcm_executor::traits::{ConvertLocation, JustTry, WeightTrader};
 use xcm_runtime_apis::conversions::LocationToAccountHelper;
@@ -1230,7 +1229,7 @@ fn receive_reserve_asset_deposited_roc_from_asset_hub_rococo_fees_paid_by_pool_s
 
 	let foreign_asset_id_location = xcm::v5::Location::new(
 		2,
-		[xcm::v5::Junction::GlobalConsensus(xcm::v5::NetworkId::ByGenesis(ROCOCO_GENESIS_HASH))],
+		[xcm::v5::Junction::GlobalConsensus(xcm::v5::NetworkId::ByGenesis(PASEO_GENESIS_HASH))],
 	);
 	let foreign_asset_id_minimum_balance = 1_000_000_000;
 	// sovereign account as foreign asset owner (can be whoever for this scenario)
@@ -1261,7 +1260,7 @@ fn receive_reserve_asset_deposited_roc_from_asset_hub_rococo_fees_paid_by_pool_s
 			},
 			(
 				[PalletInstance(bp_bridge_hub_westend::WITH_BRIDGE_WESTEND_TO_ROCOCO_MESSAGES_PALLET_INDEX)].into(),
-				GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH)),
+				GlobalConsensus(ByGenesis(PASEO_GENESIS_HASH)),
 				[Parachain(1000)].into()
 			),
 			|| {
@@ -1301,7 +1300,7 @@ fn receive_reserve_asset_deposited_roc_from_asset_hub_rococo_fees_paid_by_suffic
 
 	let foreign_asset_id_location = xcm::v5::Location::new(
 		2,
-		[xcm::v5::Junction::GlobalConsensus(xcm::v5::NetworkId::ByGenesis(ROCOCO_GENESIS_HASH))],
+		[xcm::v5::Junction::GlobalConsensus(xcm::v5::NetworkId::ByGenesis(PASEO_GENESIS_HASH))],
 	);
 	let foreign_asset_id_minimum_balance = 1_000_000_000;
 	// sovereign account as foreign asset owner (can be whoever for this scenario)
@@ -1325,7 +1324,7 @@ fn receive_reserve_asset_deposited_roc_from_asset_hub_rococo_fees_paid_by_suffic
 		bridging_to_asset_hub_rococo,
 		(
 			[PalletInstance(bp_bridge_hub_westend::WITH_BRIDGE_WESTEND_TO_ROCOCO_MESSAGES_PALLET_INDEX)].into(),
-			GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH)),
+			GlobalConsensus(ByGenesis(PASEO_GENESIS_HASH)),
 			[Parachain(1000)].into()
 		),
 		|| {
@@ -1606,7 +1605,7 @@ fn location_conversion_works() {
 		},
 		TestCase {
 			description: "Describe Rococo Location",
-			location: Location::new(2, [GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH))]),
+			location: Location::new(2, [GlobalConsensus(ByGenesis(PASEO_GENESIS_HASH))]),
 			expected_account_id_str: "5FfpYGrFybJXFsQk7dabr1vEbQ5ycBBu85vrDjPJsF3q4A8P",
 		},
 		TestCase {
@@ -1614,7 +1613,7 @@ fn location_conversion_works() {
 			location: Location::new(
 				2,
 				[
-					GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH)),
+					GlobalConsensus(ByGenesis(PASEO_GENESIS_HASH)),
 					AccountId32 { network: None, id: AccountId::from(ALICE).into() },
 				],
 			),
@@ -1625,7 +1624,7 @@ fn location_conversion_works() {
 			location: Location::new(
 				2,
 				[
-					GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH)),
+					GlobalConsensus(ByGenesis(PASEO_GENESIS_HASH)),
 					AccountKey20 { network: None, key: [0u8; 20] },
 				],
 			),
@@ -1636,7 +1635,7 @@ fn location_conversion_works() {
 			location: Location::new(
 				2,
 				[
-					GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH)),
+					GlobalConsensus(ByGenesis(PASEO_GENESIS_HASH)),
 					Plurality { id: BodyId::Treasury, part: BodyPart::Voice },
 				],
 			),
@@ -1646,7 +1645,7 @@ fn location_conversion_works() {
 			description: "Describe Rococo Parachain Location",
 			location: Location::new(
 				2,
-				[GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH)), Parachain(1000)],
+				[GlobalConsensus(ByGenesis(PASEO_GENESIS_HASH)), Parachain(1000)],
 			),
 			expected_account_id_str: "5CQeLKM7XC1xNBiQLp26Wa948cudjYRD5VzvaTG3BjnmUvLL",
 		},
@@ -1655,7 +1654,7 @@ fn location_conversion_works() {
 			location: Location::new(
 				2,
 				[
-					GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH)),
+					GlobalConsensus(ByGenesis(PASEO_GENESIS_HASH)),
 					Parachain(1000),
 					AccountId32 { network: None, id: AccountId::from(ALICE).into() },
 				],
@@ -1667,7 +1666,7 @@ fn location_conversion_works() {
 			location: Location::new(
 				2,
 				[
-					GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH)),
+					GlobalConsensus(ByGenesis(PASEO_GENESIS_HASH)),
 					Parachain(1000),
 					AccountKey20 { network: None, key: [0u8; 20] },
 				],
@@ -1679,7 +1678,7 @@ fn location_conversion_works() {
 			location: Location::new(
 				2,
 				[
-					GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH)),
+					GlobalConsensus(ByGenesis(PASEO_GENESIS_HASH)),
 					Parachain(1000),
 					Plurality { id: BodyId::Treasury, part: BodyPart::Voice },
 				],
@@ -1691,7 +1690,7 @@ fn location_conversion_works() {
 			location: Location::new(
 				2,
 				[
-					GlobalConsensus(ByGenesis(ROCOCO_GENESIS_HASH)),
+					GlobalConsensus(ByGenesis(PASEO_GENESIS_HASH)),
 					Parachain(1000),
 					PalletInstance(50),
 					GeneralIndex(1984),
@@ -1739,8 +1738,6 @@ fn xcm_payment_api_works() {
 
 #[test]
 fn governance_authorize_upgrade_works() {
-	use westend_runtime_constants::system_parachain::{ASSET_HUB_ID, COLLECTIVES_ID};
-
 	// no - random para
 	assert_err!(
 		parachains_runtimes_test_utils::test_cases::can_governance_authorize_upgrade::<


### PR DESCRIPTION
Updates ChainID for `pallet_revive` such that it doesn't overlap with Westend's.
The new ID is: `420_420_422`.