### PR TITLE
fix(revive): wrong native to eth ratio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4966,7 +4966,7 @@ dependencies = [
 
 [[package]]
 name = "passet-hub-runtime"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "asset-test-utils",
  "assets-common",

--- a/passet-hub-runtime/Cargo.toml
+++ b/passet-hub-runtime/Cargo.toml
@@ -6,7 +6,7 @@ homepage = { workspace = true }
 license = { workspace = true }
 name = "passet-hub-runtime"
 repository = { workspace = true }
-version = "0.1.1"
+version = "0.1.2"
 
 [lints]
 workspace = true

--- a/passet-hub-runtime/src/lib.rs
+++ b/passet-hub-runtime/src/lib.rs
@@ -134,7 +134,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: alloc::borrow::Cow::Borrowed("passet-hub"),
 	authoring_version: 1,
 	// The spec version from `asset-hub-westend-runtime` is periodically promoted to passet-hub's.
-	spec_version: 1_018_003,
+	spec_version: 1_018_004,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 16,
@@ -1089,7 +1089,7 @@ impl pallet_revive::Config for Runtime {
 	type CodeHashLockupDepositPercent = CodeHashLockupDepositPercent;
 	type Xcm = pallet_xcm::Pallet<Self>;
 	type ChainId = ConstU64<420_420_422>;
-	type NativeToEthRatio = ConstU32<1_000_000>; // 10^(18 - 12) Eth is 10^18, Native is 10^12.
+	type NativeToEthRatio = ConstU32<100_000_000>; // 10^(18 - 10) Eth is 10^18, Native is 10^10.
 	type EthGasEncoder = ();
 	type FindAuthor = <Runtime as pallet_authorship::Config>::FindAuthor;
 }
@@ -2465,4 +2465,13 @@ fn ensure_key_ss58() {
 	let acc =
 		AccountId::from_ss58check("5F4EbSkZz18X36xhbsjvDNs6NuZ82HyYtq5UiJ1h9SBHJXZD").unwrap();
 	assert_eq!(acc, RootMigController::sorted_members()[0]);
+}
+
+#[test]
+fn ensure_revive_native_to_eth_ratio() {
+	use std::any::TypeId;
+	assert_eq!(
+		TypeId::of::<<Runtime as pallet_revive::Config>::NativeToEthRatio>(),
+		TypeId::of::<ConstU32<100_000_000>>(),
+	);
 }


### PR DESCRIPTION
While the runtime was configured to work with a native token of 10 decimals, the provided `NativeToEthRatio` was using a ratio assuming a native token with 12 decimals.

This PR fixes this oversight and aligns the ratio configuration with the native token of 10 decimals.