### PR TITLE
chore(revive): enable `UnsafeUnstableInterface`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4987,7 +4987,7 @@ dependencies = [
 
 [[package]]
 name = "passet-hub-runtime"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "asset-test-utils",
  "assets-common",

--- a/passet-hub-runtime/Cargo.toml
+++ b/passet-hub-runtime/Cargo.toml
@@ -6,7 +6,7 @@ homepage = { workspace = true }
 license = { workspace = true }
 name = "passet-hub-runtime"
 repository = { workspace = true }
-version = "0.1.2"
+version = "0.1.3"
 
 [lints]
 workspace = true

--- a/passet-hub-runtime/src/lib.rs
+++ b/passet-hub-runtime/src/lib.rs
@@ -133,7 +133,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	impl_name: alloc::borrow::Cow::Borrowed("passet-hub"),
 	authoring_version: 1,
 	// The spec version from `asset-hub-westend-runtime` is periodically promoted to passet-hub's.
-	spec_version: 1_018_005,
+	spec_version: 1_018_006,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 16,
@@ -1082,7 +1082,7 @@ impl pallet_revive::Config for Runtime {
 	type AddressMapper = pallet_revive::AccountId32Mapper<Self>;
 	type RuntimeMemory = ConstU32<{ 128 * 1024 * 1024 }>;
 	type PVFMemory = ConstU32<{ 512 * 1024 * 1024 }>;
-	type UnsafeUnstableInterface = ConstBool<false>;
+	type UnsafeUnstableInterface = ConstBool<true>;
 	type UploadOrigin = EnsureSigned<Self::AccountId>;
 	type InstantiateOrigin = EnsureSigned<Self::AccountId>;
 	type RuntimeHoldReason = RuntimeHoldReason;


### PR DESCRIPTION
This change will allow smart contracts that can benefit from using the now marked  as [unstable hostfn](https://github.com/paritytech/polkadot-sdk/blob/83afbeeb906131755fdcea3b891ea1883c4d17d0/substrate/frame/revive/uapi/src/host.rs#L446) to effectively call into these.

While the experience users might encounter in live networks might differ from this, we believe that prioritizing access to such functionalities within the test network could be beneficial, primarily for hackathons and users working with ink!